### PR TITLE
Feature: Github Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+# Creates a job to deploy the site to Github Pages
+name: Deploy Site
+
+# Run this job whenever the repo is pushed to, or the button is pushed to manually deploy
+on: ['push', 'workflow_dispatch']
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup the pages tools
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      # Upload public directory as artifact
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload only the public directory
+          path: './public'
+
+      # Deploy it to GH Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This changeset introduces a Github Action job which publishes the site to Github Pages whenever a change is committed.

After pushing a change, check the job logs on Github to watch it deploy. It is configured to only deploy the `public` folder.